### PR TITLE
Fixed: Date picker 1 day behind

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     kotlin("kapt")
-    id("com.google.dagger.hilt.android")
+    alias(libs.plugins.dagger.hilt)
 }
 
 android {
@@ -40,11 +40,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
@@ -90,7 +90,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.9.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
     implementation ("androidx.work:work-runtime-ktx:2.10.2")
-
+    implementation(libs.kotlinx.datetime)
 
     // Room
     implementation("androidx.room:room-runtime:2.7.2")
@@ -99,9 +99,9 @@ dependencies {
     implementation("androidx.room:room-ktx:2.7.2")
 
     //Hilt
-    implementation("com.google.dagger:hilt-android:2.51.1")
-    kapt("com.google.dagger:hilt-android-compiler:2.51.1")
-    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.android.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
     implementation("com.google.accompanist:accompanist-permissions:0.37.3")
     implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
     implementation ("androidx.glance:glance-appwidget:1.1.1")

--- a/android/app/src/main/java/rocks/poopjournal/fucksgiven/presentation/ui/utils/ext.kt
+++ b/android/app/src/main/java/rocks/poopjournal/fucksgiven/presentation/ui/utils/ext.kt
@@ -1,13 +1,28 @@
 package rocks.poopjournal.fucksgiven.presentation.ui.utils
 
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.format
+import kotlinx.datetime.format.DateTimeComponents
+import kotlinx.datetime.format.MonthNames
+import kotlinx.datetime.format.Padding
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
+val dateComponentFormatter = DateTimeComponents.Format {
+    monthName(MonthNames.ENGLISH_FULL)
+    char(' ')
+    day(Padding.ZERO)
+}
+
+@OptIn(ExperimentalTime::class)
 fun getFormattedDate(timestamp: Long): String {
-    val date = Date(timestamp)
-    val sdf = SimpleDateFormat("MMMM dd", Locale.getDefault())
-    return sdf.format(date)
+    // DatePicker gives date in milliseconds since epoch UTC)
+    val localDate = Instant.fromEpochMilliseconds(timestamp).toLocalDateTime(TimeZone.UTC).date
+
+    return localDate.atStartOfDayIn(TimeZone.currentSystemDefault()).format(dateComponentFormatter)
 }
 
 fun isToday(dateString: String): Boolean {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,6 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
-    id("com.google.dagger.hilt.android") version "2.51.1" apply false
+    alias(libs.plugins.dagger.hilt) apply false
 
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,10 +1,13 @@
 [versions]
 agp = "8.6.0"
-kotlin = "2.0.21"
+hilt = "2.53.1"
+hiltNavigationCompose = "1.2.0"
+kotlin = "2.1.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+kotlinxDatetime = "0.7.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2025.06.01"
@@ -17,6 +20,9 @@ appcompat = "1.7.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -36,8 +42,10 @@ androidx-compose-material = { group = "androidx.wear.compose", name = "compose-m
 androidx-compose-foundation = { group = "androidx.wear.compose", name = "compose-foundation", version.ref = "composeFoundation" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
Fixed #149 

Switched from `java.util.Date` to `LocalDate` to prevent time zone-related rendering bugs. 
`Date` is an `Instant`, whereas `LocalDate` is the semantically correct type for a calendar date.

Changed Kotlin to `2.1.0` to access the `Instant.fromEpochMilliseconds` function. This required a corresponding Hilt update to `2.53.1` for compatibility.

Changed versions from 8 to 17, because on run the app a warning showing like this:
<img width="1393" height="289" alt="Screenshot 2025-10-10 at 11 03 39 PM" src="https://github.com/user-attachments/assets/c58f7e65-ee87-4b18-b76a-6d603a6b44ba" />

```
compileOptions {
    sourceCompatibility = JavaVersion.VERSION_17
    targetCompatibility = JavaVersion.VERSION_17
}
kotlinOptions {
    jvmTarget = "17"
}
```

**Issue Before**:

https://github.com/user-attachments/assets/e7517fe4-c16f-4501-9dc1-4b7dfa854046


**After Fix**:

https://github.com/user-attachments/assets/0361ccc6-9ea2-4b1c-918a-270b63a536d5




- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
