### PR TITLE
avoid "seven dirty words" in American English (en-US)

### DIFF
--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Fucks Given
+Something Given


### PR DESCRIPTION
In the USA, the word "fuck" is a really big deal:
https://en.wikipedia.org/wiki/Seven_dirty_words

For example, this app is already called "Something Given" in Google Play: https://play.google.com/store/apps/details?id=rocks.poopjournal.fucksgiven

Saying "fuck" in Austria is not a big deal, so I think it would be fine in a de-AT translation.  That's the contexts I know. You could add a note to the translators in Weblate that the app is called "Fucks Given" and that they should translate it according to their culture and language.

This change needs to be in place for this app to be continued to be included in f-droid.org because of the "all ages" requirement of the Inclusion Policy:
https://gitlab.com/fdroid/fdroiddata/-/work_items/3867

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
